### PR TITLE
Force alignment of tables used in AES

### DIFF
--- a/trusted/mbedtls-2.2.1/library/aes.c
+++ b/trusted/mbedtls-2.2.1/library/aes.c
@@ -198,7 +198,7 @@ static const unsigned char FSb[256] =
     V(CB,B0,B0,7B), V(FC,54,54,A8), V(D6,BB,BB,6D), V(3A,16,16,2C)
 
 #define V(a,b,c,d) 0x##a##b##c##d
-static const uint32_t FT0[256] = { FT };
+static const uint32_t FT0[256] __attribute__((aligned(0x1000))) = { FT };
 #undef V
 
 #define V(a,b,c,d) 0x##b##c##d##a
@@ -325,7 +325,7 @@ static const unsigned char RSb[256] =
     V(61,84,CB,7B), V(70,B6,32,D5), V(74,5C,6C,48), V(42,57,B8,D0)
 
 #define V(a,b,c,d) 0x##a##b##c##d
-static const uint32_t RT0[256] = { RT };
+static const uint32_t RT0[256] __attribute__((aligned(0x1000))) = { RT };
 #undef V
 
 #define V(a,b,c,d) 0x##b##c##d##a
@@ -358,7 +358,7 @@ static const uint32_t RCON[10] =
  * Forward S-box & tables
  */
 static unsigned char FSb[256];
-static uint32_t FT0[256];
+static uint32_t FT0[256] __attribute__((aligned(0x1000)));
 static uint32_t FT1[256];
 static uint32_t FT2[256];
 static uint32_t FT3[256];
@@ -367,7 +367,7 @@ static uint32_t FT3[256];
  * Reverse S-box & tables
  */
 static unsigned char RSb[256];
-static uint32_t RT0[256];
+static uint32_t RT0[256] __attribute__((aligned(0x1000)));
 static uint32_t RT1[256];
 static uint32_t RT2[256];
 static uint32_t RT3[256];


### PR DESCRIPTION
AES is vulnerable to page fault channel attack
(refer http://www.ieee-security.org/TC/SP2015/papers-archived/6949a640.pdf, https://www.comp.nus.edu.sg/~shweta24/publications/pfdefense_asiaccs16.pdf)
due to the fact that tables used for encryption(FT0, FT1, FT2, FT3) span 2 pages.
An attacker can extract some portion of key by observing page access patterns.
To prevent this, FT0, FT1, FT2, FT3 should be in a single page.
Since the size of each table is 1024 bytes, FT0, FT1, FT2, FT3 can fit
in a single page if FT0 is allocated at the start of a page.
(address of FT0 is aligned by 0x1000)

It is also same to tables for decryption(RT0, RT1, RT2, RT3).
To enforce the alignment, I added __attribute__((aligned(0x1000))) to the declarations of FT0 and RT0.