### PR TITLE
Remove accident CMake option setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ set(MBEDTLS_LIB_DIR ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 add_subdirectory(trusted)
 add_subdirectory(untrusted)
 
-SET(COMPILE_EXAMPLES YES)
-
 if (COMPILE_EXAMPLES)
     add_subdirectory(example)
 endif()


### PR DESCRIPTION
The removed line will set example always to compile, regardless of option COMPILE_EXAMPLES setting.