### PR TITLE
typo in Makefile

### DIFF
--- a/trusted/Makefile
+++ b/trusted/Makefile
@@ -1,5 +1,5 @@
 ######## Project Settings ########
-PROJECT_NAME=mbedtls_sgx
+PROJECT_NAME=mbedtls_SGX
 PROJECT_EDL=$(PROJECT_NAME).edl
 
 Enclave_Name := lib$(PROJECT_NAME)_t.a


### PR DESCRIPTION
There was a typo in the Makefile. It should now compile again with normal `make`