### PR TITLE
Fix #13: stack memory leak because of untrusted `cliip_len`

### DIFF
--- a/example/enclave/s_server.c
+++ b/example/enclave/s_server.c
@@ -1856,6 +1856,13 @@ reset:
     if( ( ret = mbedtls_net_accept_ocall( &listen_fd, &client_fd,
                     client_ip, sizeof( client_ip ), &cliip_len ) ) != 0 )
     {
+      // cliip_len is size_t, so < 0 check is not required
+      if (cliip_len > sizeof(client_ip)) {
+        mbedtls_printf(
+            " mbedtls_net_accept_ocall() returns invalid client ip length.\n");
+        ret = 0;
+        goto exit;
+      }
 #if !defined(_WIN32)
         if( received_sigterm )
         {


### PR DESCRIPTION
#13 The client ip length should not exceed sizeof(client_ip). Otherwise, there could be an stack memory leak in `mbedtls_ssl_set_client_transport_id()` and following code:
```c
int mbedtls_ssl_set_client_transport_id( mbedtls_ssl_context *ssl,
                                 const unsigned char *info,
                                 size_t ilen )
{
   ...
   memcpy( ssl->cli_id, info, ilen );
   ...
}
```